### PR TITLE
Support improved styles with spaced indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Try to create a deeply structured list and move items by pressing the hotkeys de
 
 If you liked the styles from the demo above, you can enable them in the plugin settings tab.
 
-> **Disclaimer:** Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes. Circle bullets only work well with spaces or four-space tabs. Indentation lines only work well with four-space tabs.
+> **Disclaimer:** Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes. Circle bullets only work well with spaces or four-space tabs. Indentation lines only work well with tab size 4.
 
 | Setting                                | Default value |
 | -------------------------------------- | :-----------: |

--- a/src/features/ListsStylesFeature.ts
+++ b/src/features/ListsStylesFeature.ts
@@ -42,12 +42,12 @@ export class ListsStylesFeature implements IFeature {
     let visible: boolean = false;
 
     this.interval = window.setInterval(() => {
-      const { useTab, tabSize } =
+      const { tabSize } =
         this.obsidianService.getObsidianTabsSettigns();
 
       const shouldBeVisible =
         this.settingsService.styleLists &&
-        !(useTab && tabSize === 4) &&
+        !(tabSize === 4) &&
         !this.settingsService.hideWarning;
 
       if (shouldBeVisible && !visible) {

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -149,7 +149,7 @@ export class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Improve the style of your lists")
       .setDesc(
-        "Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes. Styles only work well with spaces or four-space tabs."
+        "Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes. Styles only work well with tab size 4."
       )
       .addToggle((toggle) => {
         toggle.setValue(this.settings.styleLists).onChange(async (value) => {

--- a/styles.css
+++ b/styles.css
@@ -23,20 +23,24 @@
 }
 
 /* lines */
-.outliner-plugin-bls .cm-hmd-list-indent .cm-tab {
-  position: relative;
-}
-
-.outliner-plugin-bls .cm-hmd-list-indent .cm-tab::before {
-  content: "";
-  border-left: 1px solid var(--text-faint);
-  position: absolute;
-  left: 3px;
-  top: -9px;
-  bottom: -9999px;
-}
-
-.outliner-plugin-bls .cm-s-obsidian .CodeMirror-line {
-  position: relative;
+.outliner-plugin-bls .cm-s-obsidian .HyperMD-list-line {
   overflow: hidden;
+}
+
+.cm-hmd-list-indent {
+  position: relative;
+}
+
+.outliner-plugin-bls .CodeMirror-line .cm-hmd-list-indent::before {
+  content: '';
+  display: block;
+  position: absolute;
+  background-image: linear-gradient(to right, var(--text-faint) 1px, transparent 1px);
+  /* https://developer.mozilla.org/en-US/docs/Web/CSS/length#units */
+  background-size: 1.8ch 1px;
+  background-position-x: 3px;
+  width: 100%;
+  left: 0;
+  top: -1.6em;
+  padding-bottom: 999em;
 }


### PR DESCRIPTION
Current styling of indentation lines relies on `.cm-tab` element which is present only when "Use tabs" setting is on.

To support styling of indentation without tabs as well, instead of adding `::before` pseudo-element with border line on `.cm-tab`, a `::before` pseudo element is added to it's parent `.cm-hmd-list-indent` that is present also with spaced indentation.
Instead of using border, the lines are rendered as `background-image` with function `linear-gradient` that renders repeating pattern of vertical lines. Space between lines is defined using [ch unit](https://developer.mozilla.org/en-US/docs/Web/CSS/length#units) that is defined as _"a width of the glyph `0` in the element's font_ so it scales nicely with current font-size setting.

After testing with ~7 different themes, the new styles work with the same set of themes as original solution. It breaks mostly if a theme defines its' custom font-family. 