### PR TITLE
Allow to manipulate with multiple lines

### DIFF
--- a/src/operations/CreateNewItemOperation.ts
+++ b/src/operations/CreateNewItemOperation.ts
@@ -30,6 +30,15 @@ export class CreateNewItemOperation implements Operation {
     const { root } = this;
 
     if (!root.hasSingleCursor()) {
+      this.stopPropagation = true;
+      this.updated = true;
+      const list = root.getListUnderLine(
+        Math.min(
+          root.getSelections()[0].anchor.line,
+          root.getSelections()[0].head.line
+        )
+      );
+      root.replaceCursor(list.getFirstLineContentStart());
       return;
     }
 

--- a/src/operations/CreateNoteLineOperation.ts
+++ b/src/operations/CreateNoteLineOperation.ts
@@ -20,6 +20,7 @@ export class CreateNoteLineOperation implements Operation {
     const { root } = this;
 
     if (!root.hasSingleCursor()) {
+      this.stopPropagation = true;
       return;
     }
 


### PR DESCRIPTION
To Do

- [ ] [Auto select whole bullets when selection covers more than one bullet](https://github.com/vslinko/obsidian-outliner/discussions/105)
- [x] CreateNewItemOperation
- [x] CreateNoteLineOperation
- [ ] DeleteAndMergeWithNextLineOperation
- [ ] DeleteAndMergeWithPreviousLineOperation
- [ ] DeleteTillLineStartOperation
- [ ] EnsureCursorInListContentOperation
- [ ] EnsureCursorIsInUnfoldedLineOperation
- [ ] MoveCursorToPreviousUnfoldedLineOperation
- [ ] MoveDownOperation
- [ ] MoveLeftOperation
- [ ] MoveRightOperation
- [ ] MoveUpOperation
- [ ] OutdentIfLineIsEmptyOperation
- [ ] SelectAllOperation
- [ ] SelectTillLineStartOperation

After the release

- [ ] Archive https://github.com/vslinko/obsidian-outliner/discussions/82
- [ ] Archive https://github.com/vslinko/obsidian-outliner/discussions/105

