### PR TITLE
Correct default value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Move lists with children wherever you want without breaking the structure.
 
 | Setting                                |  Default value   |
 | -------------------------------------- | :--------------: |
-| Draw vertical indentation lines        |     `false`      |
+| Draw vertical indentation lines        |     `true`       |
 | Vertical indentation line click action | `Toggle Folding` |
 
 ### Stick the cursor to the content


### PR DESCRIPTION
Vertical lines are enabled by default. I just installed the latest version (2.2.5). The readme was incorrect.