### PR TITLE
fix minAppVersion in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-outliner",
   "name": "Outliner",
   "version": "2.3.0",
-  "minAppVersion": "0.13.23",
+  "minAppVersion": "0.15.2",
   "description": "Work with your lists like in Workflowy or RoamResearch.",
   "author": "Viacheslav Slinko",
   "authorUrl": "https://github.com/vslinko",


### PR DESCRIPTION
this PR should prevent users with older version of obsidian from updating to v2.3.0

should fix #325. 

PS: no need for new release, merging this PR and updating `manifest.json` in release manually should be enough to fix this issue. Users who accidentally update to v2.3.0 should be able to reinstall the plugin to revert to v2.2.5 when the PR is merged