### PR TITLE
Migrate plugin styles to v1.0.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-outliner",
   "name": "Outliner",
   "version": "4.0.0",
-  "minAppVersion": "0.15.9",
+  "minAppVersion": "1.0.0",
   "description": "Work with your lists like in Workflowy or RoamResearch.",
   "author": "Viacheslav Slinko",
   "authorUrl": "https://github.com/vslinko",

--- a/src/features/LinesFeature.ts
+++ b/src/features/LinesFeature.ts
@@ -173,7 +173,7 @@ class ListLinesViewPluginValue implements PluginValue {
     }
 
     const top =
-      visibleFrom > 0 && fromOffset <= visibleFrom
+      visibleFrom > 0 && fromOffset < visibleFrom
         ? -20
         : this.view.lineBlockAt(fromOffset).top;
     const bottom =

--- a/src/features/LinesFeature.ts
+++ b/src/features/LinesFeature.ts
@@ -192,7 +192,7 @@ class ListLinesViewPluginValue implements PluginValue {
       this.lines.push({
         top: top,
         left: this.getIndentSize(list),
-        height: `calc(${height}px ${hasNextSibling ? "- 1em" : "- 1.8em"})`,
+        height: `calc(${height}px ${hasNextSibling ? "- 1.5em" : "- 2em"})`,
         list,
       });
     }
@@ -201,7 +201,7 @@ class ListLinesViewPluginValue implements PluginValue {
   private getIndentSize(list: List) {
     const { tabSize } = this.obsidian.getObsidianTabsSettings();
     const indent = list.getFirstLineIndent();
-    const spaceSize = 4.5;
+    const spaceSize = 8;
 
     let spaces = 0;
     for (const char of indent) {

--- a/src/features/SettingsTabFeature.ts
+++ b/src/features/SettingsTabFeature.ts
@@ -17,7 +17,7 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Improve the style of your lists")
       .setDesc(
-        "Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes. Styles only work well with tab size 4."
+        "Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes."
       )
       .addToggle((toggle) => {
         toggle.setValue(this.settings.styleLists).onChange(async (value) => {
@@ -28,6 +28,7 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Draw vertical indentation lines")
+      .setDesc("Lines only work well with tab size 4.")
       .addToggle((toggle) => {
         toggle.setValue(this.settings.listLines).onChange(async (value) => {
           this.settings.listLines = value;

--- a/styles.css
+++ b/styles.css
@@ -36,7 +36,7 @@
   position: absolute;
   width: 5px;
   margin-left: 0.5ch;
-  margin-top: 1.4em;
+  margin-top: 1em;
   z-index: 1;
   cursor: pointer;
   background: transparent;
@@ -47,6 +47,10 @@
   );
   background-position-x: 2px;
   background-repeat: no-repeat;
+}
+
+.outliner-plugin-better-bullets .outliner-plugin-list-line {
+  margin-top: 1.4em;
 }
 
 .markdown-source-view.mod-cm6.is-readable-line-width

--- a/styles.css
+++ b/styles.css
@@ -1,28 +1,17 @@
 /* lists */
 .outliner-plugin-better-lists .cm-s-obsidian .HyperMD-list-line {
-  padding-top: 8px;
+  padding-top: 0.4px;
 }
 
 /* bullets */
-.outliner-plugin-better-bullets
-  .cm-s-obsidian:not(.is-live-preview)
-  .cm-formatting-list-ul:before,
-.outliner-plugin-better-bullets
-  .cm-s-obsidian.is-live-preview
-  .list-bullet:before {
-  visibility: visible;
-  content: "•";
-  font-size: 150%;
-  position: absolute;
-  margin-top: -6px;
-  margin-left: -3px;
-  color: var(--text-muted);
+.outliner-plugin-better-bullets .cm-formatting-list-ul {
+  margin-right: 0.3em;
 }
 
-.outliner-plugin-better-bullets
-  .cm-s-obsidian.is-live-preview
-  .list-bullet::after {
-  content: none;
+.outliner-plugin-better-bullets .list-bullet::after {
+  width: 0.4em;
+  height: 0.4em;
+  background-color: var(--text-muted);
 }
 
 /* lines */
@@ -60,24 +49,10 @@
   background-repeat: no-repeat;
 }
 
-.outliner-plugin-better-bullets .outliner-plugin-list-line {
-  margin-top: 2em;
-}
-
 .markdown-source-view.mod-cm6.is-readable-line-width
   .outliner-plugin-list-lines-content-container {
   max-width: 700px;
   margin: auto;
-}
-
-.markdown-source-view.mod-cm6.is-folding .outliner-plugin-list-line {
-  margin-left: 14px;
-}
-
-.outliner-plugin-better-bullets
-  .markdown-source-view.mod-cm6.is-folding
-  .outliner-plugin-list-line {
-  margin-left: 15px;
 }
 
 .outliner-plugin-list-line:hover {

--- a/styles.css
+++ b/styles.css
@@ -36,7 +36,7 @@
   position: absolute;
   width: 5px;
   margin-left: 0.5ch;
-  margin-top: 1.8em;
+  margin-top: 2.2em;
   z-index: 1;
   cursor: pointer;
   background: transparent;

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 /* lists */
 .outliner-plugin-better-lists .cm-s-obsidian .HyperMD-list-line {
-  padding-top: 0.4px;
+  padding-top: 0.4em;
 }
 
 /* bullets */

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  padding: 20px;
+  padding: var(--file-margins);
   padding-left: 0;
   pointer-events: none;
   overflow: hidden;
@@ -36,7 +36,7 @@
   position: absolute;
   width: 5px;
   margin-left: 0.5ch;
-  margin-top: 2.2em;
+  margin-top: 1.4em;
   z-index: 1;
   cursor: pointer;
   background: transparent;


### PR DESCRIPTION
Current plugin styles are very glitchy.

I have improved and adapted the plugin to the new version and the new design.

Only styles for lists:
<img width="536" alt="image" src="https://user-images.githubusercontent.com/6418302/195909980-89d8e867-13f6-4076-be05-74139874cdcf.png">

Styles for lines:
<img width="536" alt="image" src="https://user-images.githubusercontent.com/6418302/195910205-1f4442e3-80bf-4d65-98d5-610e87986edd.png">
