### PR TITLE
Fix: Indent lines didn't aline at the bullet with custom tab size

### DIFF
--- a/src/features/LinesFeature.ts
+++ b/src/features/LinesFeature.ts
@@ -190,8 +190,8 @@ class ListLinesViewPluginValue implements PluginValue {
           visibleTo;
 
       this.lines.push({
-        top: top,
-        left: left,
+        top,
+        left,
         height: `calc(${height}px ${hasNextSibling ? "- 1.5em" : "- 2em"})`,
         list,
       });

--- a/src/features/SettingsTabFeature.ts
+++ b/src/features/SettingsTabFeature.ts
@@ -28,7 +28,6 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Draw vertical indentation lines")
-      .setDesc("Lines only work well with tab size 4.")
       .addToggle((toggle) => {
         toggle.setValue(this.settings.listLines).onChange(async (value) => {
           this.settings.listLines = value;


### PR DESCRIPTION
Reverse-engineered the calculation of the position on the left, and now the indent line uses the same logic of native lines and works with any custom setting.