### PR TITLE
#304: Fixes the height of lines container when additional panels are …

### DIFF
--- a/src/features/LinesFeature.ts
+++ b/src/features/LinesFeature.ts
@@ -270,9 +270,21 @@ class ListLinesViewPluginValue implements PluginValue {
     const cmScroll = this.view.scrollDOM;
     const cmContent = this.view.contentDOM;
     const cmContentContainer = cmContent.parentElement;
+    const cmSizer = cmContentContainer.parentElement;
+
+    /**
+     * Obsidian can add additional elements into Content Manager.
+     * The most obvious case is the 'embedded-backlinks' core plugin that adds a menu inside a Content Manager.
+     * We must take heights of all of these elements into account
+     * to be able to calculate the correct size of lines' container.
+     */
+    let cmSizerChildrenSumHeight = 0;
+    for (let i = 0; i < cmSizer.children.length; i++) {
+      cmSizerChildrenSumHeight += cmSizer.children[i].clientHeight;
+    }
 
     this.scroller.style.top = cmScroll.offsetTop + "px";
-    this.contentContainer.style.height = cmContent.clientHeight + "px";
+    this.contentContainer.style.height = cmSizerChildrenSumHeight + "px";
     this.contentContainer.style.marginLeft =
       cmContentContainer.offsetLeft + "px";
     this.contentContainer.style.marginTop =


### PR DESCRIPTION
This fixes the height of lines container when additional panels are added to Content Manager (e.g. backlinks in document added by Backlinks core plugin).

Example before fix:

<img width="622" alt="image" src="https://user-images.githubusercontent.com/26759826/197397992-2ba2004a-f836-4987-b21e-a0ec22c6dcd4.png">

Example after fix:

<img width="627" alt="image" src="https://user-images.githubusercontent.com/26759826/197398048-5da1a8d4-6ecb-48d9-b297-af0ae420330e.png">

@vslinko  please take a look :)