### PR TITLE
Make checkboxes part of the bullet point

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
-assignees: ''
+assignees: ""
 ---
 
 **Describe the bug**
@@ -11,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/specs/ensure-cursor-in-list-content.spec.md
+++ b/specs/ensure-cursor-in-list-content.spec.md
@@ -12,6 +12,48 @@
 - |one
 ```
 
+# cursor should be moved to list content with an unchecked checkbox
+
+- applyState:
+
+```md
+|- [ ] one
+```
+
+- assertState:
+
+```md
+- [ ] |one
+```
+
+# cursor should be moved to list content with a checked checkbox
+
+- applyState:
+
+```md
+|- [x] one
+```
+
+- assertState:
+
+```md
+- [x] |one
+```
+
+# cursor should be moved to list content with a custom checkbox
+
+- applyState:
+
+```md
+- |[!] one
+```
+
+- assertState:
+
+```md
+- [!] |one
+```
+
 # cursor should not be moved to list content if stickCursor=false
 
 - setting: `stickCursor=false`
@@ -61,7 +103,7 @@
 - |two
 ```
 
-# cursor should be moved to previous line
+# cursor should be moved to previous line after arrowleft
 
 - applyState:
 

--- a/specs/enter.spec.md
+++ b/specs/enter.spec.md
@@ -299,6 +299,7 @@
 
 # enter should not create checkbox if current item contains checkbox but cursor inside checkbox
 
+- setting: `stickCursor=false`
 - applyState:
 
 ```md

--- a/src/operations/CreateNewItemOperation.ts
+++ b/src/operations/CreateNewItemOperation.ts
@@ -121,6 +121,7 @@ export class CreateNewItemOperation implements Operation {
       list.getRoot(),
       indent,
       bullet,
+      prefix.length,
       spaceAfterBullet,
       prefix + newLines.shift(),
       false

--- a/src/operations/EnsureCursorInListContentOperation.ts
+++ b/src/operations/EnsureCursorInListContentOperation.ts
@@ -30,7 +30,7 @@ export class EnsureCursorInListContentOperation implements Operation {
     const contentStart = list.getFirstLineContentStart();
     const linePrefix =
       contentStart.line === cursor.line
-        ? contentStart.ch
+        ? contentStart.ch + list.getCheckboxLength()
         : list.getNotesIndent().length;
 
     if (cursor.ch < linePrefix) {

--- a/src/root/index.ts
+++ b/src/root/index.ts
@@ -36,6 +36,7 @@ export class List {
     private root: Root,
     private indent: string,
     private bullet: string,
+    private checkboxLength: number,
     private spaceAfterBullet: string,
     firstLine: string,
     private foldRoot: boolean
@@ -211,6 +212,10 @@ export class List {
     return this.spaceAfterBullet;
   }
 
+  getCheckboxLength() {
+    return this.checkboxLength;
+  }
+
   replateBullet(bullet: string) {
     this.bullet = bullet;
   }
@@ -282,7 +287,7 @@ export class List {
 }
 
 export class Root {
-  private rootList = new List(this, "", "", "", "", false);
+  private rootList = new List(this, "", "", 0, "", "", false);
   private selections: Range[] = [];
 
   constructor(

--- a/src/services/ParserService.ts
+++ b/src/services/ParserService.ts
@@ -2,11 +2,14 @@ import { List, Root } from "../root";
 import { LoggerService } from "../services/LoggerService";
 
 const bulletSign = `(?:[-*+]|\\d+\\.)`;
+const optionalCheckbox = `(?:\\[[^\\]]\\]\\s?)?`;
 
 const listItemWithoutSpacesRe = new RegExp(`^${bulletSign}( |\t)`);
 const listItemRe = new RegExp(`^[ \t]*${bulletSign}( |\t)`);
 const stringWithSpacesRe = new RegExp(`^[ \t]+`);
-const parseListItemRe = new RegExp(`^([ \t]*)(${bulletSign})( |\t)(.*)$`);
+const parseListItemRe = new RegExp(
+  `^([ \t]*)(${bulletSign})( |\t)((${optionalCheckbox}).*)$`
+);
 
 export interface ReaderPosition {
   line: number;
@@ -159,7 +162,8 @@ export class ParserService {
       const matches = parseListItemRe.exec(line);
 
       if (matches) {
-        const [, indent, bullet, spaceAfterBullet, content] = matches;
+        const [, indent, bullet, spaceAfterBullet, content, optionalCheckbox] =
+          matches;
 
         const compareLength = Math.min(currentIndent.length, indent.length);
         const indentSlice = indent.slice(0, compareLength);
@@ -195,6 +199,7 @@ export class ParserService {
           root,
           indent,
           bullet,
+          optionalCheckbox.length,
           spaceAfterBullet,
           content,
           foldRoot


### PR DESCRIPTION
This makes checkbox list items behave more like regular list items.

Specifically it fixes the behavior of checkbox line items for the "Stick the cursor to the content" and "Enhance the Ctrl+1 or Cmd+A behavior" features.

Note: there is a slight visual glitch. The checkbox flickers when pressing Cmd/Ctrl-left. This is probably because what actually happens is that the cursor goes to the beginning of line (making the checkbox image transform into literal `[ ]` characters) for a fraction of a second before the cursor gets moved past the checkbox by the plugin. If that's the cause, addressing this visual issue would probably need the plugin to take a different, cleaner approach to handling this case (assuming such an approach exists toaday with the Obsidian APIs!).

---

Assuming the following starting point:

```
- [ ] Lorem ^Ipsum
```

Before, `Cmd/Ctrl-left` resulted in:

```
- ^[ ] Lorem Ipsum
```

After this change, `Cmd/Ctrl-left` results in:

```
- [ ] ^Lorem Ipsum
```

---

Similarly, with the following starting point:

```
- [ ] Lorem ^Ipsum
- [ ] Dolor sit amet
```

Before, the first `Cmd/Ctrl-A` resulted in the following behavior (which is unexpected because different from regular list items):

```
**- [ ] Lorem Ipsum**
- [ ] Dolor sit amet
```

Then, the second `Cmd/Ctrl-A` resulted in this weird behavior (selecting less rather than more):
```
- **[ ] Lorem Ipsum**
- [ ] Dolor sit amet
```

Finally, the third one resulted in selecting everything:
```
**- [ ] Lorem Ipsum
- [ ] Dolor sit amet**
```

After this change, the first `Cmd/Ctrl-A` results in the following (which is consistent with non-checkbox items since it selects the text of the item):
```
- [ ] **Lorem Ipsum**
- [ ] Dolor sit amet
```

And the second one now results in selecting everything (consistent with non-checkbox items):
```
**- [ ] Lorem Ipsum
- [ ] Dolor sit amet**
```