### PR TITLE
Only keep cursor out of regular checkboxes

### DIFF
--- a/specs/ensure-cursor-in-list-content.spec.md
+++ b/specs/ensure-cursor-in-list-content.spec.md
@@ -40,18 +40,18 @@
 - [x] |one
 ```
 
-# cursor should be moved to list content with a custom checkbox
+# cursor should not be moved to list content with a custom checkbox
 
 - applyState:
 
 ```md
-- |[!] one
+|- [!] one
 ```
 
 - assertState:
 
 ```md
-- [!] |one
+- |[!] one
 ```
 
 # cursor should not be moved to list content if stickCursor=false

--- a/src/operations/MoveCursorToPreviousUnfoldedLineOperation.ts
+++ b/src/operations/MoveCursorToPreviousUnfoldedLineOperation.ts
@@ -27,7 +27,9 @@ export class MoveCursorToPreviousUnfoldedLineOperation implements Operation {
     const cursor = this.root.getCursor();
     const lines = list.getLinesInfo();
     const lineNo = lines.findIndex(
-      (l) => cursor.ch === l.from.ch && cursor.line === l.from.line
+      (l) =>
+        cursor.ch === l.from.ch + list.getCheckboxLength() &&
+        cursor.line === l.from.line
     );
 
     if (lineNo === 0) {

--- a/src/services/ParserService.ts
+++ b/src/services/ParserService.ts
@@ -2,7 +2,7 @@ import { List, Root } from "../root";
 import { LoggerService } from "../services/LoggerService";
 
 const bulletSign = `(?:[-*+]|\\d+\\.)`;
-const optionalCheckbox = `(?:\\[[ xX]\\]\\s?)?`;
+const optionalCheckbox = `(?:\\[[ xX]\\]( |\t))?`;
 
 const listItemWithoutSpacesRe = new RegExp(`^${bulletSign}( |\t)`);
 const listItemRe = new RegExp(`^[ \t]*${bulletSign}( |\t)`);

--- a/src/services/ParserService.ts
+++ b/src/services/ParserService.ts
@@ -2,7 +2,7 @@ import { List, Root } from "../root";
 import { LoggerService } from "../services/LoggerService";
 
 const bulletSign = `(?:[-*+]|\\d+\\.)`;
-const optionalCheckbox = `(?:\\[[^\\]]\\]\\s?)?`;
+const optionalCheckbox = `(?:\\[[ xX]\\]\\s?)?`;
 
 const listItemWithoutSpacesRe = new RegExp(`^${bulletSign}( |\t)`);
 const listItemRe = new RegExp(`^[ \t]*${bulletSign}( |\t)`);


### PR DESCRIPTION
Keeping the cursor out of regular checkboxes (`[ ]` and `[x]`) does not allow the user to edit the contents directly, but this is not an issue because one can use the "Toggle checkbox status" command (bound to Cmd-L or Ctrl-L by default).

On the other hand, keeping the cursor out of any custom checkboxes (e.g. `[!]`) prevents the user from editing it and causes issues.

Moreover, we were previously considering e.g. `[[]` a custom checkbox (with character `[` inside the "box"), which caused additional problems when a link is added just after a bullet point (`[[]]`).

Fixes #402 