### PR TITLE
Fix checkbox corner cases, make stickCursor setting ternary to allow including checkboxes or not.

### DIFF
--- a/specs/ensure-cursor-in-list-content.spec.md
+++ b/specs/ensure-cursor-in-list-content.spec.md
@@ -40,8 +40,23 @@
 - [x] |one
 ```
 
-# cursor should not be moved to list content with a custom checkbox
+# cursor should be moved to list content with a custom checkbox
 
+- applyState:
+
+```md
+|- [!] one
+```
+
+- assertState:
+
+```md
+- [!] |one
+```
+
+# cursor should not be moved to list content with a custom checkbox if stickCursor="bullet-only"
+
+- setting: `stickCursor="bullet-only"`
 - applyState:
 
 ```md
@@ -54,9 +69,9 @@
 - |[!] one
 ```
 
-# cursor should not be moved to list content if stickCursor=false
+# cursor should not be moved to list content if stickCursor="never"
 
-- setting: `stickCursor=false`
+- setting: `stickCursor="never"`
 - applyState:
 
 ```md

--- a/specs/enter.spec.md
+++ b/specs/enter.spec.md
@@ -299,7 +299,7 @@
 
 # enter should not create checkbox if current item contains checkbox but cursor inside checkbox
 
-- setting: `stickCursor=false`
+- setting: `stickCursor="never"`
 - applyState:
 
 ```md
@@ -394,7 +394,7 @@
 
 # enter should not create new item if cursor is before line start
 
-- setting: `stickCursor=false`
+- setting: `stickCursor="never"`
 - applyState:
 
 ```md

--- a/specs/selection.spec.md
+++ b/specs/selection.spec.md
@@ -15,6 +15,40 @@
   - |two|
 ```
 
+# cmd-a should select list item content excluding checkbox
+
+- applyState:
+
+```md
+- one
+  - [ ] two|
+```
+
+- keydown: `Cmd-KeyA`
+- assertState:
+
+```md
+- one
+  - [ ] |two|
+```
+
+# cmd-a should select list item content excluding custom checkbox
+
+- applyState:
+
+```md
+- one
+    - [!] two|
+```
+
+- keydown: `Cmd-KeyA`
+- assertState:
+
+```md
+- one
+    - [!] |two|
+```
+
 # cmd-a should select list item content with notes
 
 - applyState:
@@ -69,6 +103,37 @@ b
 
 ```md
 - |one|
+```
+
+# Cmd-Shift-Left should select content only excluding checkbox
+
+- applyState:
+
+```md
+- [ ] one|
+```
+
+- keydown: `Cmd-Shift-ArrowLeft`
+- assertState:
+
+```md
+- [ ] |one|
+```
+
+# Cmd-Shift-Left should select content not including custom checkboxes
+
+- setting: `stickCursor="bullet-and-checkbox"`
+- applyState:
+
+```md
+- [!] one|
+```
+
+- keydown: `Cmd-Shift-ArrowLeft`
+- assertState:
+
+```md
+- [!] |one|
 ```
 
 # Cmd-Shift-Left should select one note line only

--- a/src/ObsidianOutlinerPlugin.ts
+++ b/src/ObsidianOutlinerPlugin.ts
@@ -42,7 +42,7 @@ export default class ObsidianOutlinerPlugin extends Plugin {
 
     this.logger = new LoggerService(this.settings);
 
-    this.parser = new ParserService(this.logger);
+    this.parser = new ParserService(this.logger, this.settings);
     this.applyChanges = new ApplyChangesService();
     this.performOperation = new PerformOperationService(
       this.parser,

--- a/src/__mocks__.ts
+++ b/src/__mocks__.ts
@@ -2,6 +2,7 @@
 import { MyEditor } from "./MyEditor";
 import { LoggerService } from "./services/LoggerService";
 import { ParserService } from "./services/ParserService";
+import { SettingsService } from "./services/SettingsService";
 
 export interface EditorMockParams {
   text: string;
@@ -38,14 +39,23 @@ export function makeLoggerService(): LoggerService {
   return logger;
 }
 
+export function makeSettingsService(): SettingsService {
+  const settings: any = {
+    stickCursor: "bullet-and-checkbox",
+  };
+  return settings;
+}
+
 export function makeRoot(options: {
   editor: MyEditor;
+  settings?: SettingsService;
   logger?: LoggerService;
 }) {
-  const { logger, editor } = {
+  const { logger, editor, settings } = {
     logger: makeLoggerService(),
+    settings: makeSettingsService(),
     ...options,
   };
 
-  return new ParserService(logger).parse(editor);
+  return new ParserService(logger, settings).parse(editor);
 }

--- a/src/features/DeleteShouldIgnoreBulletsFeature.ts
+++ b/src/features/DeleteShouldIgnoreBulletsFeature.ts
@@ -53,7 +53,7 @@ export class DeleteShouldIgnoreBulletsFeature implements Feature {
   async unload() {}
 
   private check = () => {
-    return this.settings.stickCursor && !this.ime.isIMEOpened();
+    return this.settings.stickCursor != "never" && !this.ime.isIMEOpened();
   };
 
   private deleteAndMergeWithPreviousLine = (editor: MyEditor) => {

--- a/src/features/EnsureCursorInListContentFeature.ts
+++ b/src/features/EnsureCursorInListContentFeature.ts
@@ -27,7 +27,7 @@ export class EnsureCursorInListContentFeature implements Feature {
   async unload() {}
 
   private transactionExtender = (tr: Transaction): null => {
-    if (!this.settings.stickCursor || !tr.selection) {
+    if (this.settings.stickCursor == "never" || !tr.selection) {
       return null;
     }
 

--- a/src/features/MoveCursorToPreviousUnfoldedLineFeature.ts
+++ b/src/features/MoveCursorToPreviousUnfoldedLineFeature.ts
@@ -44,7 +44,7 @@ export class MoveCursorToPreviousUnfoldedLineFeature implements Feature {
   async unload() {}
 
   private check = () => {
-    return this.settings.stickCursor && !this.ime.isIMEOpened();
+    return this.settings.stickCursor != "never" && !this.ime.isIMEOpened();
   };
 
   private run = (editor: MyEditor) => {

--- a/src/features/SelectionShouldIgnoreBulletsFeature.ts
+++ b/src/features/SelectionShouldIgnoreBulletsFeature.ts
@@ -37,7 +37,7 @@ export class SelectionShouldIgnoreBulletsFeature implements Feature {
   async unload() {}
 
   private check = () => {
-    return this.settings.stickCursor && !this.ime.isIMEOpened();
+    return this.settings.stickCursor != "never" && !this.ime.isIMEOpened();
   };
 
   private run = (editor: MyEditor) => {

--- a/src/features/SettingsTabFeature.ts
+++ b/src/features/SettingsTabFeature.ts
@@ -2,7 +2,11 @@ import { App, PluginSettingTab, Plugin_2, Setting } from "obsidian";
 
 import { Feature } from "./Feature";
 
-import { ListLineAction, SettingsService } from "../services/SettingsService";
+import {
+  ListLineAction,
+  SettingsService,
+  StickCursor,
+} from "../services/SettingsService";
 
 class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
   constructor(app: App, plugin: Plugin_2, private settings: SettingsService) {
@@ -54,11 +58,18 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Stick the cursor to the content")
       .setDesc("Don't let the cursor move to the bullet position.")
-      .addToggle((toggle) => {
-        toggle.setValue(this.settings.stickCursor).onChange(async (value) => {
-          this.settings.stickCursor = value;
-          await this.settings.save();
-        });
+      .addDropdown((dropdown) => {
+        dropdown
+          .addOptions({
+            never: "Never",
+            "bullet-only": "Stick cursor out of bullets",
+            "bullet-and-checkbox": "Stick cursor out of bullets and checkboxes",
+          } as { [key in StickCursor]: string })
+          .setValue(this.settings.stickCursor)
+          .onChange(async (value) => {
+            this.settings.stickCursor = value as StickCursor;
+            await this.settings.save();
+          });
       });
 
     new Setting(containerEl)

--- a/src/operations/CreateNewItemOperation.ts
+++ b/src/operations/CreateNewItemOperation.ts
@@ -2,7 +2,7 @@ import { Operation } from "./Operation";
 
 import { List, Position, Root } from "../root";
 import { recalculateNumericBullets } from "../root/recalculateNumericBullets";
-import { checkboxRe } from "../services/ParserService";
+import { checkboxRe } from "../utils/checkboxRe";
 import { isEmptyLineOrEmptyCheckbox } from "../utils/isEmptyLineOrEmptyCheckbox";
 
 export interface GetZoomRange {

--- a/src/operations/CreateNewItemOperation.ts
+++ b/src/operations/CreateNewItemOperation.ts
@@ -2,6 +2,7 @@ import { Operation } from "./Operation";
 
 import { List, Position, Root } from "../root";
 import { recalculateNumericBullets } from "../root/recalculateNumericBullets";
+import { checkboxRe } from "../services/ParserService";
 import { isEmptyLineOrEmptyCheckbox } from "../utils/isEmptyLineOrEmptyCheckbox";
 
 export interface GetZoomRange {
@@ -115,13 +116,13 @@ export class CreateNewItemOperation implements Operation {
         ? list.getChildren()[0].getSpaceAfterBullet()
         : list.getSpaceAfterBullet();
 
-    const prefix = oldLines[0].match(/^\[.\]/) ? "[ ] " : "";
+    const prefix = oldLines[0].match(checkboxRe) ? "[ ] " : "";
 
     const newList = new List(
       list.getRoot(),
       indent,
       bullet,
-      prefix.length,
+      prefix,
       spaceAfterBullet,
       prefix + newLines.shift(),
       false

--- a/src/operations/EnsureCursorInListContentOperation.ts
+++ b/src/operations/EnsureCursorInListContentOperation.ts
@@ -27,10 +27,10 @@ export class EnsureCursorInListContentOperation implements Operation {
 
     const cursor = root.getCursor();
     const list = root.getListUnderCursor();
-    const contentStart = list.getFirstLineContentStart();
+    const contentStart = list.getFirstLineContentStartAfterCheckbox();
     const linePrefix =
       contentStart.line === cursor.line
-        ? contentStart.ch + list.getCheckboxLength()
+        ? contentStart.ch
         : list.getNotesIndent().length;
 
     if (cursor.ch < linePrefix) {

--- a/src/operations/MoveCursorToPreviousUnfoldedLineOperation.ts
+++ b/src/operations/MoveCursorToPreviousUnfoldedLineOperation.ts
@@ -26,11 +26,12 @@ export class MoveCursorToPreviousUnfoldedLineOperation implements Operation {
     const list = this.root.getListUnderCursor();
     const cursor = this.root.getCursor();
     const lines = list.getLinesInfo();
-    const lineNo = lines.findIndex(
-      (l) =>
+    const lineNo = lines.findIndex((l) => {
+      return (
         cursor.ch === l.from.ch + list.getCheckboxLength() &&
         cursor.line === l.from.line
-    );
+      );
+    });
 
     if (lineNo === 0) {
       this.moveCursorToPreviousUnfoldedItem(root, cursor);

--- a/src/operations/SelectAllOperation.ts
+++ b/src/operations/SelectAllOperation.ts
@@ -46,7 +46,7 @@ export class SelectAllOperation implements Operation {
     }
 
     const list = root.getListUnderCursor();
-    const contentStart = list.getFirstLineContentStart();
+    const contentStart = list.getFirstLineContentStartAfterCheckbox();
     const contentEnd = list.getLastLineContentEnd();
 
     if (
@@ -65,10 +65,10 @@ export class SelectAllOperation implements Operation {
       selectionTo.line === contentEnd.line &&
       selectionTo.ch === contentEnd.ch
     ) {
-      // select all list
+      // select whole list
       root.replaceSelections([{ anchor: rootStart, head: rootEnd }]);
     } else {
-      // select all line
+      // select whole line
       root.replaceSelections([{ anchor: contentStart, head: contentEnd }]);
     }
 

--- a/src/operations/SelectTillLineStartOperation.ts
+++ b/src/operations/SelectTillLineStartOperation.ts
@@ -1,6 +1,6 @@
 import { Operation } from "./Operation";
 
-import { Root } from "../root";
+import { Position, Root } from "../root";
 
 export class SelectTillLineStartOperation implements Operation {
   private stopPropagation = false;
@@ -30,7 +30,13 @@ export class SelectTillLineStartOperation implements Operation {
     const list = root.getListUnderCursor();
     const lines = list.getLinesInfo();
     const lineNo = lines.findIndex((l) => l.from.line === cursor.line);
+    const offset = lineNo === 0 ? list.getCheckboxLength() : 0;
 
-    root.replaceSelections([{ head: lines[lineNo].from, anchor: cursor }]);
+    const newHead: Position = {
+      ch: lines[lineNo].from.ch + offset,
+      line: lines[lineNo].from.line,
+    };
+
+    root.replaceSelections([{ head: newHead, anchor: cursor }]);
   }
 }

--- a/src/operations/__tests__/CreateNewItemOperation.test.ts
+++ b/src/operations/__tests__/CreateNewItemOperation.test.ts
@@ -1,4 +1,4 @@
-import { makeEditor, makeRoot } from "../../__mocks__";
+import { makeEditor, makeRoot, makeSettingsService } from "../../__mocks__";
 import { CreateNewItemOperation } from "../CreateNewItemOperation";
 
 test("should create sibling bullet instead of child bullet if child bullets are folded", () => {
@@ -8,6 +8,7 @@ test("should create sibling bullet instead of child bullet if child bullets are 
       cursor: { line: 0, ch: 5 },
       getAllFoldedLines: () => [0],
     }),
+    settings: makeSettingsService(),
   });
   const getZoomRange = {
     getZoomRange: (): null => null,

--- a/src/root/index.ts
+++ b/src/root/index.ts
@@ -36,7 +36,7 @@ export class List {
     private root: Root,
     private indent: string,
     private bullet: string,
-    private checkboxLength: number,
+    private optionalCheckbox: string,
     private spaceAfterBullet: string,
     firstLine: string,
     private foldRoot: boolean
@@ -114,6 +114,15 @@ export class List {
     return {
       line: startLine,
       ch: this.getContentStartCh(),
+    };
+  }
+
+  getFirstLineContentStartAfterCheckbox() {
+    const startLine = this.root.getContentLinesRangeOf(this)[0];
+
+    return {
+      line: startLine,
+      ch: this.getContentStartCh() + this.optionalCheckbox.length,
     };
   }
 
@@ -213,7 +222,7 @@ export class List {
   }
 
   getCheckboxLength() {
-    return this.checkboxLength;
+    return this.optionalCheckbox.length;
   }
 
   replateBullet(bullet: string) {
@@ -287,7 +296,7 @@ export class List {
 }
 
 export class Root {
-  private rootList = new List(this, "", "", 0, "", "", false);
+  private rootList = new List(this, "", "", "", "", "", false);
   private selections: Range[] = [];
 
   constructor(

--- a/src/services/ParserService.ts
+++ b/src/services/ParserService.ts
@@ -2,9 +2,9 @@ import { SettingsService } from "./SettingsService";
 
 import { List, Root } from "../root";
 import { LoggerService } from "../services/LoggerService";
+import { checkboxRe } from "../utils/checkboxRe";
 
 const bulletSignRe = `(?:[-*+]|\\d+\\.)`;
-export const checkboxRe = `\\[[^\\[\\]]\\][ \t]`;
 const optionalCheckboxRe = `(?:${checkboxRe})?`;
 
 const listItemWithoutSpacesRe = new RegExp(`^${bulletSignRe}( |\t)`);

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -1,9 +1,10 @@
 export type ListLineAction = "none" | "zoom-in" | "toggle-folding";
+export type StickCursor = "never" | "bullet-only" | "bullet-and-checkbox";
 
 export interface ObsidianOutlinerPluginSettings {
   styleLists: boolean;
   debug: boolean;
-  stickCursor: boolean;
+  stickCursor: StickCursor | boolean;
   betterEnter: boolean;
   betterTab: boolean;
   selectAll: boolean;
@@ -14,7 +15,7 @@ export interface ObsidianOutlinerPluginSettings {
 const DEFAULT_SETTINGS: ObsidianOutlinerPluginSettings = {
   styleLists: true,
   debug: false,
-  stickCursor: true,
+  stickCursor: "bullet-and-checkbox",
   betterEnter: true,
   betterTab: true,
   selectAll: true,
@@ -55,9 +56,15 @@ export class SettingsService implements ObsidianOutlinerPluginSettings {
   }
 
   get stickCursor() {
+    // Adaptor for users migrating from older version of the plugin.
+    if (this.values.stickCursor === true) {
+      return "bullet-and-checkbox";
+    } else if (this.values.stickCursor === false) {
+      return "never";
+    }
     return this.values.stickCursor;
   }
-  set stickCursor(value: boolean) {
+  set stickCursor(value: StickCursor) {
     this.set("stickCursor", value);
   }
 

--- a/src/services/__tests__/ParserService.test.ts
+++ b/src/services/__tests__/ParserService.test.ts
@@ -1,19 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { makeEditor, makeLoggerService } from "../../__mocks__";
+import {
+  makeEditor,
+  makeLoggerService,
+  makeSettingsService,
+} from "../../__mocks__";
 import { LoggerService } from "../LoggerService";
 import { ParserService } from "../ParserService";
+import { SettingsService } from "../SettingsService";
 
 function makeParserService(
   options: {
     logger?: LoggerService;
+    settings?: SettingsService;
   } = {}
 ) {
-  const { logger } = {
+  const { logger, settings } = {
     logger: makeLoggerService(),
+    settings: makeSettingsService(),
     ...options,
   };
 
-  return new ParserService(logger);
+  return new ParserService(logger, settings);
 }
 
 describe("parseList", () => {

--- a/src/utils/checkboxRe.ts
+++ b/src/utils/checkboxRe.ts
@@ -1,0 +1,1 @@
+export const checkboxRe = `\\[[^\\[\\]]\\][ \t]`;


### PR DESCRIPTION
POC to fix Cmd-a and Cmd-shift-left behavior when using checkboxes. The behavior is fine but the code is not very clean...

This is probably not the best place but I have a few (interrelated) thoughts to share so I'll dump them here for now. Happy to move then to e.g. a GH Issue or whichever place is more adapted.

### Thought 1 (update the List class)

The approach to handling checkboxes is starting to feel a bit spaghetti-like with these offsets I'm adding at the last minute. I feel like the `List` class needs to be amended, but I'm not 100% how yet. A checkbox is neither a bullet not a plain "content":
- it's not "just a bullet" because it should not be blindly copied to the next line when pressing `Enter` (`- [x] myline|` should insert `- [ ] `, not `- [x] `).
- it's not "just a bullet" because when handling pressing `Enter` in `- [ |] myline` (to split the box in half, when `settings.stickCursor` is `false`), the implementation currently uses `lines` to determine whether the cursor is inside the box. This requires the checkbox to be part of `lines` (which the bullet isn't).
- it's not "just contents" because obviously we need to handle checkboxes specially to get cursor out of it etc.

I'll try to wrap my head around that.

### Thought 2 (avoid moving the cursor again after a move)

Currently, the implementation is such that a cursor that is in the bullet/checkbox area will be automatically moved out of it. I think this participates in the two bugs that [these tests](https://github.com/vslinko/obsidian-outliner/commit/f17d922a619db584ba52942f0eafde29e8401f16) surface (looks like there's a kind of race condition due to Obsidian changing the checkbox from text-to-image and vice versa, and the selection's anchor `ch` gets set to `0`). It is also what makes Cmd-left look glitchy (the cursor moves to the left, Obsidian changes the checkbox into text, then outliner moves the cursor after the checkbox, Obsidian changes the checkbox back into a square image).

Do you think it would be desirable to handle this differently, namely to override keystrokes (left, right, etc.) in such a way that the cursor never ends up within the bullet/checkbox (even for a fraction of a second)? This is for example what is done for `leftArrow` handling today.

Having to handle the different hotkeys individually is more work, but it would mean we avoid the non-trivial issues above. 

If the cursor ends up in that bullet/checkbox area (e.g. when clicking there in source mode), then... we'd leave it in there? I'm thinking it might avoid potential incompatibilities in the future, e.g. with other plugins that won't expect the cursor to automatically move. It's also possible to keep the current "move away cursor" behavior as a last resort mechanism.

### Thought 3 (custom checkboxes UX):

This is a tricky one: on the one hand it would be great to manage custom checkboxes such as `[!]`, but on the other hand, if we don't let the cursor get in there, users won't be able to amend the value. Regular checkboxes have the `Cmd-L` hotkey for that so they're fine.

Moreover, I would say the current behavior is a regression from pre-`4.1.0`: users that use custom checkbox have a worse UX now than they used to do (see first item below).

Possible approaches:
1. have outliner ignore custom checkboxes (current behaviour). Main issues: it's hard for the user to change `- [ ]` to `- [!]`. Also, the cursor behavior is inconsistent between `- [ ]` (handled by outliner) and `- [!] ` (not handled). 
2. have outliner consider custom checkboxes like regular ones. Main issues: it's hard for the user to change `- [ ]` from *and* to `- [!]`. But at least, it's custom- vs regular- checkbox behavior is consistent, and power users with custom-checkbox hotkeys have the best experience.
3. change the "stickCursor" setting to allow "anywhere", "outside bullet", "outside bullet and checkbox" (can be done in conjuction with either 1. or 2.). Main issues: custom-checkbox users won't reap the benefits from outliner's checkbox handling, but at least their experience is not a regression compared to pre-`4.1.0` version.