### PR TITLE
Change behaviors of ⌘A / ⌃A: Extend selection by level

### DIFF
--- a/src/operations/SelectAllContent.ts
+++ b/src/operations/SelectAllContent.ts
@@ -46,6 +46,7 @@ export class SelectAllContent implements Operation {
     }
 
     const list = root.getListUnderCursor();
+    const listEnd = list.getContentEndIncludingChildren();
     const contentStart = list.getFirstLineContentStartAfterCheckbox();
     const contentEnd = list.getLastLineContentEnd();
 
@@ -62,11 +63,19 @@ export class SelectAllContent implements Operation {
     if (
       selectionFrom.line === contentStart.line &&
       selectionFrom.ch === contentStart.ch &&
-      selectionTo.line === contentEnd.line &&
-      selectionTo.ch === contentEnd.ch
+      selectionTo.line === listEnd.line &&
+      selectionTo.ch === listEnd.ch
     ) {
       // select whole list
       root.replaceSelections([{ anchor: rootStart, head: rootEnd }]);
+    } else if (
+      selectionFrom.line === contentStart.line &&
+      selectionFrom.ch === contentStart.ch &&
+      selectionTo.line === contentEnd.line &&
+      selectionTo.ch === contentEnd.ch
+    ) {
+      // select sublists
+      root.replaceSelections([{ anchor: contentStart, head: listEnd }]);
     } else {
       // select whole line
       root.replaceSelections([{ anchor: contentStart, head: contentEnd }]);

--- a/src/operations/SelectAllContent.ts
+++ b/src/operations/SelectAllContent.ts
@@ -49,7 +49,8 @@ export class SelectAllContent implements Operation {
     const contentStart = list.getFirstLineContentStartAfterCheckbox();
     const contentEnd = list.getLastLineContentEnd();
     const listUnderSelectionFrom = root.getListUnderLine(selectionFrom.line);
-    const listStart = listUnderSelectionFrom.getFirstLineContentStartAfterCheckbox();
+    const listStart =
+      listUnderSelectionFrom.getFirstLineContentStartAfterCheckbox();
     const listEnd = listUnderSelectionFrom.getContentEndIncludingChildren();
 
     this.stopPropagation = true;
@@ -58,20 +59,33 @@ export class SelectAllContent implements Operation {
     if (
       selectionFrom.line === contentStart.line &&
       selectionFrom.ch === contentStart.ch &&
-      selectionTo.line === listEnd.line &&
-      selectionTo.ch === listEnd.ch
+      selectionTo.line === contentEnd.line &&
+      selectionTo.ch === contentEnd.ch
     ) {
-      if (list.children.length) {
+      if (list.getChildren().length) {
         // select sub lists
-        root.replaceSelections([{ anchor: contentStart, head: list.getContentEndIncludingChildren() }]);
+        root.replaceSelections([
+          { anchor: contentStart, head: list.getContentEndIncludingChildren() },
+        ]);
       } else {
         // select whole list
         root.replaceSelections([{ anchor: rootStart, head: rootEnd }]);
       }
-    } else if (listStart.ch == selectionFrom.ch && listEnd.line == selectionTo.line && listEnd.ch == selectionTo.ch) {
+    } else if (
+      listStart.ch == selectionFrom.ch &&
+      listEnd.line == selectionTo.line &&
+      listEnd.ch == selectionTo.ch
+    ) {
       // select whole list
       root.replaceSelections([{ anchor: rootStart, head: rootEnd }]);
-    } else if ((selectionFrom.line > contentStart.line || (selectionFrom.line == contentStart.line && selectionFrom.ch >= contentStart.ch)) && (selectionTo.line < contentEnd.line || (selectionTo.line == contentEnd.line && selectionTo.ch <= contentEnd.ch))) {
+    } else if (
+      (selectionFrom.line > contentStart.line ||
+        (selectionFrom.line == contentStart.line &&
+          selectionFrom.ch >= contentStart.ch)) &&
+      (selectionTo.line < contentEnd.line ||
+        (selectionTo.line == contentEnd.line &&
+          selectionTo.ch <= contentEnd.ch))
+    ) {
       // select whole line
       root.replaceSelections([{ anchor: contentStart, head: contentEnd }]);
     } else {

--- a/src/operations/SelectAllContent.ts
+++ b/src/operations/SelectAllContent.ts
@@ -46,7 +46,6 @@ export class SelectAllContent implements Operation {
     }
 
     const list = root.getListUnderCursor();
-    const listEnd = list.getContentEndIncludingChildren();
     const contentStart = list.getFirstLineContentStartAfterCheckbox();
     const contentEnd = list.getLastLineContentEnd();
     const listUnderSelectionFrom = root.getListUnderLine(selectionFrom.line);

--- a/src/operations/__tests__/SelectAllContent.test.ts
+++ b/src/operations/__tests__/SelectAllContent.test.ts
@@ -1,0 +1,32 @@
+import { makeEditor, makeRoot, makeSettings } from "../../__mocks__";
+import { SelectAllContent } from "../SelectAllContent";
+
+test("when performed the first time, should select the whole line under cursor; when performed the second time, should select all sub-bullets of the cursor line if it is a parent-bullet, otherwise select the whole list", () => {
+  const root = makeRoot({
+    editor: makeEditor({
+      text: "- item 1\n- item 2\n    - item 2.1\n    - item 2.2\n- item 3\n",
+      cursor: { line: 1, ch: 2 },
+    }),
+    settings: makeSettings(),
+  });
+
+  const op = new SelectAllContent(root);
+
+  op.perform();
+  expect(root.getSelection().anchor.line).toBe(1);
+  expect(root.getSelection().anchor.ch).toBe(2);
+  expect(root.getSelection().head.line).toBe(1);
+  expect(root.getSelection().head.ch).toBe(8);
+
+  op.perform();
+  expect(root.getSelection().anchor.line).toBe(1);
+  expect(root.getSelection().anchor.ch).toBe(2);
+  expect(root.getSelection().head.ch).toBe(14);
+  expect(root.getSelection().head.line).toBe(3);
+
+  op.perform();
+  expect(root.getSelection().anchor.line).toBe(0);
+  expect(root.getSelection().anchor.ch).toBe(0);
+  expect(root.getSelection().head.line).toBe(4);
+  expect(root.getSelection().head.ch).toBe(8);
+});

--- a/src/operations/__tests__/SelectAllContent.test.ts
+++ b/src/operations/__tests__/SelectAllContent.test.ts
@@ -1,7 +1,7 @@
 import { makeEditor, makeRoot, makeSettings } from "../../__mocks__";
 import { SelectAllContent } from "../SelectAllContent";
 
-test("when performed the first time, should select the whole line under cursor; when performed the second time, should select all sub-bullets of the cursor line if it is a parent-bullet, otherwise select the whole list", () => {
+test("when performed the first time, should select the whole line under cursor; when performed the second time, should select all sub-bullets of the cursor line if it is a parent-bullet", () => {
   const root = makeRoot({
     editor: makeEditor({
       text: "- item 1\n- item 2\n    - item 2.1\n    - item 2.2\n- item 3\n",
@@ -23,6 +23,30 @@ test("when performed the first time, should select the whole line under cursor; 
   expect(root.getSelection().anchor.ch).toBe(2);
   expect(root.getSelection().head.ch).toBe(14);
   expect(root.getSelection().head.line).toBe(3);
+
+  op.perform();
+  expect(root.getSelection().anchor.line).toBe(0);
+  expect(root.getSelection().anchor.ch).toBe(0);
+  expect(root.getSelection().head.line).toBe(4);
+  expect(root.getSelection().head.ch).toBe(8);
+});
+
+test("when a whole line is selected and the selected line has no sub-bullets, should select the whole list", () => {
+  const root = makeRoot({
+    editor: makeEditor({
+      text: "- item 1\n- item 2\n    - item 2.1\n    - item 2.2\n- item 3\n",
+      cursor: { line: 4, ch: 2 },
+    }),
+    settings: makeSettings(),
+  });
+
+  const op = new SelectAllContent(root);
+
+  op.perform();
+  expect(root.getSelection().anchor.line).toBe(4);
+  expect(root.getSelection().anchor.ch).toBe(2);
+  expect(root.getSelection().head.line).toBe(4);
+  expect(root.getSelection().head.ch).toBe(8);
 
   op.perform();
   expect(root.getSelection().anchor.line).toBe(0);


### PR DESCRIPTION
Current list item -> All sublists of current list item -> The whole list.