### PR TITLE
Resolve Drag and Drop error in Obsidian 1.5.3+

### DIFF
--- a/src/features/DragAndDrop.ts
+++ b/src/features/DragAndDrop.ts
@@ -356,7 +356,9 @@ class DragAndDropState {
         ch: 0,
       });
 
-      v.top = view.coordsAtPos(linePos, -1).top;
+      const coords = view.coordsAtPos(linePos, -1);
+      const vTop = coords ? coords.top : 0;
+      v.top = vTop;
 
       if (positionAfterList) {
         v.top += view.lineBlockAt(linePos).height;


### PR DESCRIPTION
This change is to resolve the issue in Obsidian 1.5.3+ where drag and drop is no longer possible.

https://github.com/vslinko/obsidian-outliner/issues/506