### PR TITLE
Added option for Vim mode to make `o` and `O` insert bullets and behave more like the enhanced "enter"

### DIFF
--- a/src/ObsidianOutlinerPlugin.ts
+++ b/src/ObsidianOutlinerPlugin.ts
@@ -18,6 +18,7 @@ import { ShiftTabBehaviourOverride } from "./features/ShiftTabBehaviourOverride"
 import { SystemInfo } from "./features/SystemInfo";
 import { TabBehaviourOverride } from "./features/TabBehaviourOverride";
 import { VerticalLines } from "./features/VerticalLines";
+import { VimOBehaviourOverride } from "./features/VimOBehaviourOverride";
 import { ChangesApplicator } from "./services/ChangesApplicator";
 import { IMEDetector } from "./services/IMEDetector";
 import { Logger } from "./services/Logger";
@@ -124,6 +125,14 @@ export default class ObsidianOutlinerPlugin extends Plugin {
         this,
         this.settings,
         this.imeDetector,
+        this.obsidianSettings,
+        this.parser,
+        this.operationPerformer,
+      ),
+
+      new VimOBehaviourOverride(
+        this,
+        this.settings,
         this.obsidianSettings,
         this.parser,
         this.operationPerformer,

--- a/src/ObsidianOutlinerPlugin.ts
+++ b/src/ObsidianOutlinerPlugin.ts
@@ -130,6 +130,7 @@ export default class ObsidianOutlinerPlugin extends Plugin {
         this.operationPerformer,
       ),
 
+      // features based on settings.overrideVimOBehaviour
       new VimOBehaviourOverride(
         this,
         this.settings,

--- a/src/features/SettingsTab.ts
+++ b/src/features/SettingsTab.ts
@@ -1,7 +1,6 @@
 import { App, Plugin, PluginSettingTab, Setting } from "obsidian";
 
 import { Feature } from "./Feature";
-import { VimOBehaviourOverride } from "./VimOBehaviourOverride";
 
 import {
   KeepCursorWithinContent,
@@ -71,7 +70,6 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
         toggle
           .setValue(this.settings.overrideVimOBehaviour)
           .onChange(async (value) => {
-            VimOBehaviourOverride.toggle(value);
             this.settings.overrideVimOBehaviour = value;
             await this.settings.save();
           });

--- a/src/features/SettingsTab.ts
+++ b/src/features/SettingsTab.ts
@@ -1,6 +1,7 @@
 import { App, Plugin, PluginSettingTab, Setting } from "obsidian";
 
 import { Feature } from "./Feature";
+import { VimOBehaviourOverride } from "./VimOBehaviourOverride";
 
 import {
   KeepCursorWithinContent,
@@ -59,6 +60,19 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
           .setValue(this.settings.overrideEnterBehaviour)
           .onChange(async (value) => {
             this.settings.overrideEnterBehaviour = value;
+            await this.settings.save();
+          });
+      });
+
+    new Setting(containerEl)
+      .setName("Vim-mode o/O inserts bullets")
+      .setDesc("Create a bullet when pressing o or O in Vim mode.")
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.settings.overrideVimOBehaviour)
+          .onChange(async (value) => {
+            VimOBehaviourOverride.toggle(value);
+            this.settings.overrideVimOBehaviour = value;
             await this.settings.save();
           });
       });

--- a/src/features/VimOBehaviourOverride.ts
+++ b/src/features/VimOBehaviourOverride.ts
@@ -1,0 +1,140 @@
+import { MarkdownView, Plugin } from "obsidian";
+
+import { MyEditor } from "src/editor";
+import { CreateNewItem } from "src/operations/CreateNewItem";
+import { ObsidianSettings } from "src/services/ObsidianSettings";
+import { OperationPerformer } from "src/services/OperationPerformer";
+import { Parser } from "src/services/Parser";
+import { Settings } from "src/services/Settings";
+
+import { Feature } from "./Feature";
+
+export class VimOBehaviourOverride implements Feature {
+  static toggle(enabled: boolean) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vim = (window as any).CodeMirrorAdapter?.Vim;
+    if (enabled && vim) {
+      console.log("VimOBehaviourOverride enabled");
+      vim.mapCommand(
+        "o",
+        "action",
+        "insertLineAfterBullet",
+        {},
+        {
+          isEdit: true,
+          context: "normal",
+          interlaceInsertRepeat: true,
+          actionArgs: { after: true },
+        },
+      );
+      vim.mapCommand(
+        "O",
+        "action",
+        "insertLineAfterBullet",
+        {},
+        {
+          isEdit: true,
+          context: "normal",
+          interlaceInsertRepeat: true,
+          actionArgs: { after: false },
+        },
+      );
+    } else {
+      console.log("VimOBehaviourOverride disabled");
+      vim.mapCommand(
+        "o",
+        "action",
+        "newLineAndEnterInsertMode",
+        {},
+        {
+          isEdit: true,
+          context: "normal",
+          interlaceInsertRepeat: true,
+          actionArgs: { after: true },
+        },
+      );
+      vim.mapCommand(
+        "O",
+        "action",
+        "newLineAndEnterInsertMode",
+        {},
+        {
+          isEdit: true,
+          context: "normal",
+          interlaceInsertRepeat: true,
+          actionArgs: { after: false },
+        },
+      );
+      // vim.unmap("o", "normal")
+      // vim.unmap("O", "normal")
+    }
+  }
+
+  constructor(
+    private plugin: Plugin,
+    private settings: Settings,
+    private obsidianSettings: ObsidianSettings,
+    private parser: Parser,
+    private operationPerformer: OperationPerformer,
+  ) {}
+
+  async load() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vim = (window as any).CodeMirrorAdapter?.Vim;
+    const plugin = this.plugin;
+    const parser = this.parser;
+    const obsidianSettings = this.obsidianSettings;
+    const operationPerformer = this.operationPerformer;
+
+    VimOBehaviourOverride.toggle(this.settings.overrideVimOBehaviour);
+
+    vim.defineAction(
+      "insertLineAfterBullet",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function (cm: any, operatorArgs: { after: boolean }) {
+        // vim.enterInsertMode(cm, {insertAt: 'charAfter'})
+        // Sort of janky way to get into insert mode with cursor after the
+        // character.  Ideally, this would call `enterInsertMode` with the
+        // `actionArgs` but I haven't found an API for doing that.
+        //
+        // { keys: 'a', type: 'action', action: 'enterInsertMode', isEdit: true, actionArgs: { insertAt: 'charAfter' }, context: 'normal' },
+        vim.handleKey(cm, "a");
+        const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+        const editor = new MyEditor(view.editor);
+        const root = parser.parse(editor);
+
+        if (!root) {
+          return {
+            shouldUpdate: false,
+            shouldStopPropagation: false,
+          };
+        }
+
+        const defaultIndentChars = obsidianSettings.getDefaultIndentChars();
+        const zoomRange = editor.getZoomRange();
+        const getZoomRange = {
+          getZoomRange: () => zoomRange,
+        };
+
+        const res = operationPerformer.eval(
+          root,
+          new CreateNewItem(
+            root,
+            defaultIndentChars,
+            getZoomRange,
+            operatorArgs.after,
+          ),
+          editor,
+        );
+
+        if (res.shouldUpdate && zoomRange) {
+          editor.tryRefreshZoom(zoomRange.from.line);
+        }
+
+        return res;
+      },
+    );
+  }
+
+  async unload() {}
+}

--- a/src/operations/CreateNewItem.ts
+++ b/src/operations/CreateNewItem.ts
@@ -16,6 +16,7 @@ export class CreateNewItem implements Operation {
     private root: Root,
     private defaultIndentChars: string,
     private getZoomRange: GetZoomRange,
+    private after: boolean = true,
   ) {}
 
   shouldStopPropagation() {
@@ -145,7 +146,11 @@ export class CreateNewItem implements Operation {
         }
       }
 
-      list.getParent().addAfter(list, newList);
+      if (this.after) {
+        list.getParent().addAfter(list, newList);
+      } else {
+        list.getParent().addBefore(list, newList);
+      }
     }
 
     list.replaceLines(oldLines);

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -9,6 +9,7 @@ interface SettingsObject {
   debug: boolean;
   stickCursor: KeepCursorWithinContent | boolean;
   betterEnter: boolean;
+  betterVimO: boolean;
   betterTab: boolean;
   selectAll: boolean;
   listLines: boolean;
@@ -22,6 +23,7 @@ const DEFAULT_SETTINGS: SettingsObject = {
   debug: false,
   stickCursor: "bullet-and-checkbox",
   betterEnter: true,
+  betterVimO: true,
   betterTab: true,
   selectAll: true,
   listLines: false,
@@ -76,6 +78,14 @@ export class Settings {
 
   set overrideEnterBehaviour(value: boolean) {
     this.set("betterEnter", value);
+  }
+
+  get overrideVimOBehaviour() {
+    return this.values.betterVimO;
+  }
+
+  set overrideVimOBehaviour(value: boolean) {
+    this.set("betterVimO", value);
   }
 
   get overrideSelectAllBehaviour() {


### PR DESCRIPTION
Fixes https://github.com/vslinko/obsidian-outliner/issues/460

Demo:

https://github.com/vslinko/obsidian-outliner/assets/903365/333e49a1-8e9d-452c-bc3b-409dbc059c9a

I went ahead and added an option to toggle whether this should be enabled, but I suspect if you're using the vim keymap you will want to have this enabled so I can remove the setting and enable it for all if you'd prefer to keep the settings simple.