### PR TITLE
Add auto-expand selection across multiple list items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1844,6 +1845,7 @@
       "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1854,6 +1856,7 @@
       "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "style-mod": "^4.1.0",
@@ -3461,6 +3464,7 @@
       "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -3542,6 +3546,7 @@
       "integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.25.0",
         "@typescript-eslint/types": "8.25.0",
@@ -3750,6 +3755,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4076,6 +4082,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4543,6 +4550,7 @@
       "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6824,6 +6832,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6870,6 +6879,7 @@
       "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7161,6 +7171,7 @@
       "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -7564,7 +7575,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7608,6 +7620,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/features/EditorSelectionsBehaviourOverride.ts
+++ b/src/features/EditorSelectionsBehaviourOverride.ts
@@ -5,6 +5,7 @@ import { EditorState, Transaction } from "@codemirror/state";
 import { Feature } from "./Feature";
 
 import { MyEditor, getEditorFromState } from "../editor";
+import { ExpandSelectionToFullItems } from "../operations/ExpandSelectionToFullItems";
 import { KeepCursorOutsideFoldedLines } from "../operations/KeepCursorOutsideFoldedLines";
 import { KeepCursorWithinListContent } from "../operations/KeepCursorWithinListContent";
 import { OperationPerformer } from "../services/OperationPerformer";
@@ -57,6 +58,25 @@ export class EditorSelectionsBehaviourOverride implements Feature {
 
       if (shouldStopPropagation) {
         return;
+      }
+    }
+
+    // Only try to expand selection if it spans multiple lines (actual selection, not cursor)
+    if (this.settings.expandSelection) {
+      const selections = root.getSelections();
+      if (
+        selections.length === 1 &&
+        selections[0].anchor.line !== selections[0].head.line
+      ) {
+        const { shouldStopPropagation } = this.operationPerformer.eval(
+          root,
+          new ExpandSelectionToFullItems(root),
+          editor,
+        );
+
+        if (shouldStopPropagation) {
+          return;
+        }
       }
     }
 

--- a/src/features/SettingsTab.ts
+++ b/src/features/SettingsTab.ts
@@ -90,6 +90,20 @@ class ObsidianOutlinerPluginSettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
+      .setName("Auto-expand selection to full list items")
+      .setDesc(
+        "When selecting across multiple bullets, automatically expand the selection to include full list items with their children.",
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.settings.expandSelection)
+          .onChange(async (value) => {
+            this.settings.expandSelection = value;
+            await this.settings.save();
+          });
+      });
+
+    new Setting(containerEl)
       .setName("Improve the style of your lists")
       .setDesc(
         "Styles are only compatible with built-in Obsidian themes and may not be compatible with other themes.",

--- a/src/operations/ExpandSelectionToFullItems.ts
+++ b/src/operations/ExpandSelectionToFullItems.ts
@@ -1,0 +1,78 @@
+import { Operation } from "./Operation";
+
+import { Root, cmpPos, maxPos, minPos } from "../root";
+
+export class ExpandSelectionToFullItems implements Operation {
+  private stopPropagation = false;
+  private updated = false;
+
+  constructor(private root: Root) {}
+
+  shouldStopPropagation() {
+    return this.stopPropagation;
+  }
+
+  shouldUpdate() {
+    return this.updated;
+  }
+
+  perform() {
+    const { root } = this;
+
+    if (!root.hasSingleSelection()) {
+      return;
+    }
+
+    const selection = root.getSelections()[0];
+    const { anchor, head } = selection;
+
+    // Only expand if selection spans multiple lines
+    if (anchor.line === head.line) {
+      return;
+    }
+
+    const [rootStart, rootEnd] = root.getContentRange();
+
+    const selectionFrom = minPos(anchor, head);
+    const selectionTo = maxPos(anchor, head);
+
+    // Check if selection is within the list bounds
+    if (
+      selectionFrom.line < rootStart.line ||
+      selectionTo.line > rootEnd.line
+    ) {
+      return;
+    }
+
+    const listAtFrom = root.getListUnderLine(selectionFrom.line);
+    const listAtTo = root.getListUnderLine(selectionTo.line);
+
+    if (!listAtFrom || !listAtTo) {
+      return;
+    }
+
+    // Calculate the expanded range
+    const expandedStart = listAtFrom.getFirstLineContentStartAfterCheckbox();
+    const expandedEnd = listAtTo.getContentEndIncludingChildren();
+
+    // Check if selection is already expanded (to avoid infinite loops)
+    if (
+      cmpPos(selectionFrom, expandedStart) === 0 &&
+      cmpPos(selectionTo, expandedEnd) === 0
+    ) {
+      return;
+    }
+
+    // Preserve selection direction (anchor/head order)
+    const isForward = cmpPos(anchor, head) <= 0;
+
+    this.stopPropagation = true;
+    this.updated = true;
+
+    if (isForward) {
+      root.replaceSelections([{ anchor: expandedStart, head: expandedEnd }]);
+    } else {
+      root.replaceSelections([{ anchor: expandedEnd, head: expandedStart }]);
+    }
+  }
+}

--- a/src/operations/__tests__/ExpandSelectionToFullItems.test.ts
+++ b/src/operations/__tests__/ExpandSelectionToFullItems.test.ts
@@ -1,0 +1,255 @@
+import { makeEditor, makeRoot, makeSettings } from "../../__mocks__";
+import { ExpandSelectionToFullItems } from "../ExpandSelectionToFullItems";
+
+describe("ExpandSelectionToFullItems operation", () => {
+  test("should expand selection across two bullets to full items", () => {
+    const editor = makeEditor({
+      text: "- item 1\n- item 2\n- item 3\n",
+      cursor: { line: 0, ch: 5 },
+    });
+
+    // Mock selection from middle of item 1 to middle of item 2
+    editor.listSelections = () => [
+      { anchor: { line: 0, ch: 5 }, head: { line: 1, ch: 5 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(true);
+    expect(op.shouldStopPropagation()).toBe(true);
+
+    const selection = root.getSelection();
+    // Should expand to start of item 1 content
+    expect(selection.anchor.line).toBe(0);
+    expect(selection.anchor.ch).toBe(2);
+    // Should expand to end of item 2
+    expect(selection.head.line).toBe(1);
+    expect(selection.head.ch).toBe(8);
+  });
+
+  test("should include children when expanding selection", () => {
+    const editor = makeEditor({
+      text: "- item 1\n- item 2\n    - item 2.1\n    - item 2.2\n- item 3\n",
+      cursor: { line: 0, ch: 5 },
+    });
+
+    // Mock selection from item 1 to item 2 (which has children)
+    editor.listSelections = () => [
+      { anchor: { line: 0, ch: 5 }, head: { line: 1, ch: 5 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(true);
+
+    const selection = root.getSelection();
+    // Should expand to start of item 1 content
+    expect(selection.anchor.line).toBe(0);
+    expect(selection.anchor.ch).toBe(2);
+    // Should expand to end of item 2.2 (last child of item 2)
+    expect(selection.head.line).toBe(3);
+    expect(selection.head.ch).toBe(14);
+  });
+
+  test("should not modify single-line selection", () => {
+    const editor = makeEditor({
+      text: "- item 1\n- item 2\n",
+      cursor: { line: 0, ch: 5 },
+    });
+
+    // Mock single-line selection
+    editor.listSelections = () => [
+      { anchor: { line: 0, ch: 3 }, head: { line: 0, ch: 7 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(false);
+    expect(op.shouldStopPropagation()).toBe(false);
+  });
+
+  test("should not modify already-expanded selection", () => {
+    const editor = makeEditor({
+      text: "- item 1\n- item 2\n",
+      cursor: { line: 0, ch: 2 },
+    });
+
+    // Mock selection already covering full items
+    editor.listSelections = () => [
+      { anchor: { line: 0, ch: 2 }, head: { line: 1, ch: 8 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(false);
+    expect(op.shouldStopPropagation()).toBe(false);
+  });
+
+  test("should work with checkboxes", () => {
+    const editor = makeEditor({
+      text: "- [ ] task 1\n- [ ] task 2\n",
+      cursor: { line: 0, ch: 8 },
+    });
+
+    // Mock selection from middle of task 1 to middle of task 2
+    editor.listSelections = () => [
+      { anchor: { line: 0, ch: 8 }, head: { line: 1, ch: 8 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(true);
+
+    const selection = root.getSelection();
+    // Should expand to start of task 1 content (after checkbox)
+    expect(selection.anchor.line).toBe(0);
+    expect(selection.anchor.ch).toBe(6);
+    // Should expand to end of task 2
+    expect(selection.head.line).toBe(1);
+    expect(selection.head.ch).toBe(12);
+  });
+
+  test("should preserve backward selection direction", () => {
+    const editor = makeEditor({
+      text: "- item 1\n- item 2\n- item 3\n",
+      cursor: { line: 1, ch: 5 },
+    });
+
+    // Mock backward selection (head before anchor)
+    editor.listSelections = () => [
+      { anchor: { line: 1, ch: 5 }, head: { line: 0, ch: 5 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(true);
+
+    const selection = root.getSelection();
+    // Anchor should be at end (backward selection)
+    expect(selection.anchor.line).toBe(1);
+    expect(selection.anchor.ch).toBe(8);
+    // Head should be at start
+    expect(selection.head.line).toBe(0);
+    expect(selection.head.ch).toBe(2);
+  });
+
+  test("should not do anything if there are multiple selections", () => {
+    const editor = makeEditor({
+      text: "- item 1\n- item 2\n- item 3\n",
+      cursor: { line: 0, ch: 5 },
+    });
+
+    // Mock multiple selections
+    editor.listSelections = () => [
+      { anchor: { line: 0, ch: 3 }, head: { line: 0, ch: 7 } },
+      { anchor: { line: 1, ch: 3 }, head: { line: 1, ch: 7 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(false);
+    expect(op.shouldStopPropagation()).toBe(false);
+  });
+
+  test("should expand selection across nested items correctly", () => {
+    const editor = makeEditor({
+      text: "- parent 1\n    - child 1.1\n    - child 1.2\n- parent 2\n",
+      cursor: { line: 1, ch: 8 },
+    });
+
+    // Mock selection from child 1.1 to parent 2
+    editor.listSelections = () => [
+      { anchor: { line: 1, ch: 8 }, head: { line: 3, ch: 5 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(true);
+
+    const selection = root.getSelection();
+    // Should start at child 1.1 content start
+    expect(selection.anchor.line).toBe(1);
+    expect(selection.anchor.ch).toBe(6);
+    // Should end at parent 2 end
+    expect(selection.head.line).toBe(3);
+    expect(selection.head.ch).toBe(10);
+  });
+
+  test("should handle selection starting from a child item", () => {
+    const editor = makeEditor({
+      text: "- parent 1\n    - child 1.1\n        - grandchild\n    - child 1.2\n- parent 2\n",
+      cursor: { line: 1, ch: 8 },
+    });
+
+    // Mock selection from child 1.1 to child 1.2
+    editor.listSelections = () => [
+      { anchor: { line: 1, ch: 8 }, head: { line: 3, ch: 8 } },
+    ];
+
+    const root = makeRoot({
+      editor,
+      settings: makeSettings(),
+    });
+
+    const op = new ExpandSelectionToFullItems(root);
+    op.perform();
+
+    expect(op.shouldUpdate()).toBe(true);
+
+    const selection = root.getSelection();
+    // Should start at child 1.1 content start
+    expect(selection.anchor.line).toBe(1);
+    expect(selection.anchor.ch).toBe(6);
+    // Should end at child 1.2 (which has no children)
+    expect(selection.head.line).toBe(3);
+    expect(selection.head.ch).toBe(14);
+  });
+});

--- a/src/services/Settings.ts
+++ b/src/services/Settings.ts
@@ -12,6 +12,7 @@ interface SettingsObject {
   betterVimO: boolean;
   betterTab: boolean;
   selectAll: boolean;
+  expandSelection: boolean;
   listLines: boolean;
   listLineAction: VerticalLinesAction;
   dnd: boolean;
@@ -26,6 +27,7 @@ const DEFAULT_SETTINGS: SettingsObject = {
   betterVimO: true,
   betterTab: true,
   selectAll: true,
+  expandSelection: true,
   listLines: false,
   listLineAction: "toggle-folding",
   dnd: true,
@@ -94,6 +96,14 @@ export class Settings {
 
   set overrideSelectAllBehaviour(value: boolean) {
     this.set("selectAll", value);
+  }
+
+  get expandSelection() {
+    return this.values.expandSelection;
+  }
+
+  set expandSelection(value: boolean) {
+    this.set("expandSelection", value);
   }
 
   get betterListsStyles() {


### PR DESCRIPTION
When selecting text across multiple bullets, the selection now automatically expands to cover full list items including children. Similar to Dynalist/WorkFlowy behavior.

New setting: Auto-expand selection to full list items (on by default)

![CleanShot 2025-12-07 at 00 08 22](https://github.com/user-attachments/assets/9d1862a7-c13f-4f97-9530-466cfc1bb5f6)
