### PR TITLE
Fix drag detection on right-clicks and overlay elements

### DIFF
--- a/src/features/DragAndDrop.ts
+++ b/src/features/DragAndDrop.ts
@@ -106,7 +106,8 @@ export class DragAndDrop implements Feature {
     if (
       !isFeatureSupported() ||
       !this.settings.dragAndDrop ||
-      !isClickOnBullet(e)
+      !isClickOnBullet(e) ||
+      e.button !== 0
     ) {
       return;
     }
@@ -557,8 +558,12 @@ function getEditorViewFromHTMLElement(e: HTMLElement) {
 }
 
 function isClickOnBullet(e: MouseEvent) {
-  let el = e.target as HTMLElement;
+  const target = e.target as HTMLElement;
+  if (!target.closest('.cm-content')) {
+    return false;
+  }
 
+  let el = target;
   while (el) {
     if (
       el.classList.contains("cm-formatting-list") ||
@@ -567,10 +572,8 @@ function isClickOnBullet(e: MouseEvent) {
     ) {
       return true;
     }
-
     el = el.parentElement;
   }
-
   return false;
 }
 


### PR DESCRIPTION
## Problem:
Right-clicking or middle-clicking on list bullets/checkboxes currently initiates the drag-and-drop feature, causing unintended behavior:
- The context menu appears but the drag state remains active
- Any subsequent mouse movement is interpreted as a drag operation
- This conflicts with plugins that use right-click for other features (e.g., [Checkbox Style Menu](https://github.com/ReticentEclectic/checkbox-style-menu))

## Solution:
Added two checks to prevent non-left-click buttons from triggering drag:

1. Button check in `handleMouseDown`: Only `button === 0` (left-click) can initiate drag
2. Content area check in `isClickOnBullet`: Ignore clicks on checkboxes within overlays/menus (outside `.cm-content`)