### PR TITLE
Fix vim O inserting child instead of sibling above

### DIFF
--- a/src/operations/CreateNewItem.ts
+++ b/src/operations/CreateNewItem.ts
@@ -98,7 +98,8 @@ export class CreateNewItem implements Operation {
     const endOfLine = cursor.line === endPos.line && cursor.ch === endPos.ch;
 
     const onChildLevel =
-      listIsZoomingRoot || (hasChildren && !childIsFolded && endOfLine);
+      this.after &&
+      (listIsZoomingRoot || (hasChildren && !childIsFolded && endOfLine));
 
     const indent = onChildLevel
       ? hasChildren
@@ -138,7 +139,7 @@ export class CreateNewItem implements Operation {
     if (onChildLevel) {
       list.addBeforeAll(newList);
     } else {
-      if (!childIsFolded || !endOfLine) {
+      if (this.after && (!childIsFolded || !endOfLine)) {
         const children = list.getChildren();
         for (const child of children) {
           list.removeChild(child);

--- a/src/operations/__tests__/CreateNewItem.test.ts
+++ b/src/operations/__tests__/CreateNewItem.test.ts
@@ -235,6 +235,23 @@ describe("CreateNewItem operation", () => {
     expect(root.print()).toBe("- zoomed\n  - \n  - child");
   });
 
+  test("should create sibling above (not child) when after=false and item has unfolded children", () => {
+    const root = makeRoot({
+      editor: makeEditor({
+        text: "- 1\n- 2\n  - a\n- 3\n",
+        cursor: { line: 1, ch: 3 },
+      }),
+      settings: makeSettings(),
+    });
+
+    const op = new CreateNewItem(root, "  ", getZoomRange, false);
+    op.perform();
+
+    expect(root.print()).toBe("- 1\n- \n- 2\n  - a\n- 3");
+    expect(root.getCursor().line).toBe(1);
+    expect(root.getCursor().ch).toBe(2);
+  });
+
   test("should not move children when not at end of line", () => {
     const root = makeRoot({
       editor: makeEditor({


### PR DESCRIPTION
## Summary

In vim mode, pressing `O` on a list item with unfolded children opened the new bullet as the first child instead of a sibling above.

`CreateNewItem`'s `onChildLevel` and children-transfer branches ignored the `after` flag, so `O` (`after=false`) followed the same code path as `o` (`after=true`). Both branches are now gated on `after`.

### Before
```
- 1
- 2|      ← cursor here, "- 2" has an unfolded child "- a"
  - a
- 3
```
Pressing `O` produced:
```
- 1
- 2
  - |     ← new bullet inserted as first child
  - a
- 3
```

### After
```
- 1
- |       ← new bullet inserted as sibling above
- 2
  - a
- 3
```

## Test plan

- Added a unit test in `CreateNewItem.test.ts` covering `after=false` with an item that has unfolded children.
- `npm run test:unit` passes.
- Tested this for a week on my personal vault, works flawlessly.


Thanks for this great plugin!